### PR TITLE
Sentencia script de update_join

### DIFF
--- a/Sprint 02/Back-MVC/consultas_select_update.sql
+++ b/Sprint 02/Back-MVC/consultas_select_update.sql
@@ -1,0 +1,15 @@
+
+/*CONSULTA USANDO UPDATE*/
+
+UPDATE UsuarioMedico SET Nombre = Carlos_Albaro WHERE localidad = SanJusto;
+UPDATE UsuarioPaciente SET ObraSocial='SWIS MEDICA' WHERE apellido = Rios_Aguirre;
+UPDATE EstudioMedico SET fecha='2022/02/23'WHERE paciente= JulianMarquez;
+
+
+/*CONSULTA USANDO JOIN*/
+
+SELECT * 
+FROM EstudioMedico  
+INNER JOIN UsuarioPaciente ON MedicoSolicitante_id=MedicodeCabecera_id
+
+


### PR DESCRIPTION
INNER JOIN:
Une dos tablas en función de una columna común comparando cada fila de la primera tabla con cada fila de la segunda tabla.
Si los valores de ambas filas coinciden, la cláusula de INNER JOIN crea una nueva fila cuya columna contiene todas las columnas de las dos filas de ambas tablas e incluye esta nueva fila en el conjunto de resultados.
La cláusula de INNER JOIN solo incluye filas coincidentes de ambas tablas como se puede ver en el siguiente ejemplo:

UPDATE:
Permite actualizar registros de una tabla. Debemos por lo tanto indicar que registros se quiere actualizar mediante la cláusula WHERE, y que campos mediante la cláusula SET, además se deberá indicar que nuevo dato va a guardar cada campo. Omitir la cláusula WHERE en una instrucción UPDATE implica aplicar la actualización a todos los registros de la tabla. 

